### PR TITLE
Because No

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/scientist.dm
@@ -23,4 +23,3 @@
 	new /obj/item/device/assembly/flash/handheld(src)
 	new /obj/item/device/laser_pointer(src)
 	new /obj/item/weapon/door_remote/research_director(src)
-	new /obj/item/weapon/storage/box/firingpins(src)

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -205,7 +205,7 @@
 
 /datum/supply_pack/security/laser
 	name = "Lasers Crate"
-	cost = 1500
+	cost = 3500
 	contains = list(/obj/item/weapon/gun/energy/laser,
 					/obj/item/weapon/gun/energy/laser,
 					/obj/item/weapon/gun/energy/laser)
@@ -244,7 +244,7 @@
 
 /datum/supply_pack/security/armory/riothelmets
 	name = "Riot Helmets Crate"
-	cost = 1500
+	cost = 4500
 	contains = list(/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot,
 					/obj/item/clothing/head/helmet/riot)
@@ -252,7 +252,7 @@
 
 /datum/supply_pack/security/armory/riotarmor
 	name = "Riot Armor Crate"
-	cost = 1500
+	cost = 4500
 	contains = list(/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/suit/armor/riot,
 					/obj/item/clothing/suit/armor/riot)
@@ -260,7 +260,7 @@
 
 /datum/supply_pack/security/armory/riotshields
 	name = "Riot Shields Crate"
-	cost = 2000
+	cost = 4500
 	contains = list(/obj/item/weapon/shield/riot,
 					/obj/item/weapon/shield/riot,
 					/obj/item/weapon/shield/riot)
@@ -268,7 +268,7 @@
 
 /datum/supply_pack/security/armory/bulletarmor
 	name = "Bulletproof Armor Crate"
-	cost = 1500
+	cost = 2500
 	contains = list(/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof,
 					/obj/item/clothing/suit/armor/bulletproof)
@@ -276,7 +276,7 @@
 
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
-	cost = 6000
+	cost = 20000
 	contains = list(/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/head/helmet/swat/nanotrasen,
 					/obj/item/clothing/suit/space/swat,
@@ -299,7 +299,7 @@
 
 /datum/supply_pack/security/armory/laserarmor
 	name = "Reflector Vest Crate"
-	cost = 2000
+	cost = 2500
 	contains = list(/obj/item/clothing/suit/armor/laserproof,
 					/obj/item/clothing/suit/armor/laserproof)
 	crate_name = "reflector vest crate"
@@ -318,7 +318,7 @@
 
 /datum/supply_pack/security/armory/energy
 	name = "Energy Guns Crate"
-	cost = 2500
+	cost = 5500
 	contains = list(/obj/item/weapon/gun/energy/gun,
 					/obj/item/weapon/gun/energy/gun)
 	crate_name = "energy gun crate"
@@ -341,7 +341,7 @@
 
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Auto Rifle Crate"
-	cost = 3500
+	cost = 5500
 	contains = list(/obj/item/weapon/gun/projectile/automatic/wt550,
 					/obj/item/weapon/gun/projectile/automatic/wt550)
 	crate_name = "auto rifle crate"
@@ -390,7 +390,7 @@
 
 /datum/supply_pack/security/firingpins
 	name = "Standard Firing Pins Crate"
-	cost = 1000
+	cost = 25000
 	contains = list(/obj/item/weapon/storage/box/firingpins,
 					/obj/item/weapon/storage/box/firingpins)
 	crate_name = "firing pins crate"

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -46,9 +46,9 @@
 	name = "Telescopic Riot Shield"
 	desc = "An advanced riot shield made of lightweight materials that collapses for easy storage."
 	id = "tele_shield"
-	req_tech = list("combat" = 4, "materials" = 3, "engineering" = 4)
+	req_tech = list("combat" = 5, "materials" = 4, "engineering" = 4)
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 4000, MAT_GLASS = 5000, MAT_SILVER = 300)
+	materials = list(MAT_METAL = 4000, MAT_GLASS = 5000, MAT_SILVER = 3000)
 	build_path = /obj/item/weapon/shield/riot/tele
 	category = list("Weapons")
 
@@ -198,6 +198,8 @@
 	category = list("Weapons")
 
 //WT550 Mags
+// Literally cancer - Poojawa
+/*
 
 /datum/design/mag_oldsmg
 	name = "WT-550 Auto Gun Magazine (4.6x30mm)"
@@ -229,7 +231,7 @@
 	id = "mag_oldsmg_tx"
 	materials = list(MAT_METAL = 6000, MAT_SILVER = 600, MAT_URANIUM = 2000)
 	build_path = /obj/item/ammo_box/magazine/wt550m9/wttx
-
+*/
 /datum/design/stunshell
 	name = "Stun Shell"
 	desc = "A stunning shell for a shotgun."


### PR DESCRIPTION
Increses cost for some security equipment from Cargonia, not that it'll matter until goofnomics is removed. Armorygonia is bad.

Removes firing pins from RD locker. Seriously no.

Removes assault rifle ammo from protolathe.
